### PR TITLE
fix yarn command typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install [**yarn**](https://yarnpkg.com/en/docs/install) package manager.
 Install `gitter-archive-cli` as global.
 
 ```sh
-$ yarn global gitter-archive-cli
+$ yarn add global gitter-archive-cli
 
 # OR
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install [**yarn**](https://yarnpkg.com/en/docs/install) package manager.
 Install `gitter-archive-cli` as global.
 
 ```sh
-$ yarn add global gitter-archive-cli
+$ yarn global add gitter-archive-cli
 
 # OR
 


### PR DESCRIPTION
`yarn global gitter-archive-cli` should be `yarn global add gitter-archive-cli`